### PR TITLE
3월 첫째주 

### DIFF
--- a/jieun/3월첫째주/pgm_가장먼노드.java
+++ b/jieun/3월첫째주/pgm_가장먼노드.java
@@ -1,0 +1,45 @@
+import java.util.*;
+
+public class pgm_가장먼노드 {
+
+    public int solution(int n, int[][] edge) {
+        boolean[][] node = new boolean[n + 1][n + 1];
+        int[] dist = new int[n + 1];
+        int max = 0;
+
+        for (int i = 0; i < edge.length; i++) {
+            int x = edge[i][0];
+            int y = edge[i][1];
+            node[x][y] = true;
+            node[y][x] = true;
+        }
+
+        Queue<Integer> q = new LinkedList<>();
+        q.add(1);
+        dist[1] = 0;
+
+        while (!q.isEmpty()) {
+            int k = q.poll();
+
+            for (int i = 2; i <= n; i++) {
+                if (dist[i] == 0 && node[k][i]) { // dist=0 이 방문 배열을 대신함
+                    dist[i] = dist[k] + 1;
+                    q.add(i);
+                }
+            }
+        }
+
+        for (int i = 0; i < n + 1; i++) {
+            max = Math.max(max, dist[i]);
+        }
+
+        int answer = 0;
+        for (int i = 0; i < n + 1; i++) {
+            if (max == dist[i])
+                answer++;
+        }
+
+        return answer;
+    }
+
+}

--- a/jieun/3월첫째주/pgm_네트워크.java
+++ b/jieun/3월첫째주/pgm_네트워크.java
@@ -1,0 +1,31 @@
+import java.util.*;
+
+public class pgm_네트워크 {
+
+    public boolean[] visited;
+
+    public int solution(int n, int[][] computers) {
+        visited = new boolean[n];
+        int answer = 0;
+
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                dfs(i, n, computers);
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+
+    public void dfs(int x, int n, int[][] computers) {
+        visited[x] = true;
+        for (int i = 0; i < n; i++) {
+            if (computers[x][i] == 1 && !visited[i]) {
+                dfs(i, n, computers);
+            }
+        }
+
+    }
+
+}

--- a/jieun/3월첫째주/pgm_단어변환.java
+++ b/jieun/3월첫째주/pgm_단어변환.java
@@ -1,0 +1,37 @@
+public class pgm_단어변환 {
+    int answer = 0;
+    boolean[] visited;
+
+    public int solution(String begin, String target, String[] words) {
+        visited = new boolean[words.length];
+        dfs(begin, target, words, 0);
+
+        return answer;
+    }
+
+    public void dfs(String begin, String target, String[] words, int cnt) {
+        if (begin.equals(target)) {
+            answer = cnt;
+            return;
+        }
+
+        for (int i = 0; i < words.length; i++) {
+            if (visited[i]) {
+                continue;
+            }
+
+            int check = 0;
+            for (int j = 0; j < begin.length(); j++) {
+                if (begin.charAt(j) == words[i].charAt(j)) {
+                    check++;
+                }
+            }
+
+            if (check == begin.length() - 1) {
+                visited[i] = true;
+                dfs(words[i], target, words, cnt + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}

--- a/jieun/3월첫째주/pgm_여행경로.java
+++ b/jieun/3월첫째주/pgm_여행경로.java
@@ -1,0 +1,37 @@
+import java.util.*;
+
+public class pgm_여행경로 {
+    boolean[] ticketUsed; // 방문 여부 체크하는  배열
+    ArrayList<String> result; // 티켓을 사용하는 경로의 경우의 수
+
+    public String[] solution(String[][] tickets) {
+        ticketUsed = new boolean[tickets.length];
+        result = new ArrayList<>();
+        dfs("ICN", "ICN", 0, tickets);
+
+        // 답들중 가장 알파벳순이 빠른 배열들로 정렬
+        Collections.sort(result);
+
+        // 첫번째 경로를 잘라서 리턴
+        return result.get(0).split(" ");
+    }
+
+    public void dfs(String now, String nodes, int count, String[][] tickets) {
+        // 사용한 티켓의 수가 전체 티켓의 수와 같아진 경우 = 모든 공항을 들렸다면
+        if (count == tickets.length) {
+            result.add(nodes);
+            return;
+        }
+
+        // 티켓 배열 순회
+        for (int i = 0; i < tickets.length; i++) {
+            // 티켓 아직 사용하지 않았고 해당 티켓의 출발지가 현재 위치와 같은 경우
+            if (!ticketUsed[i] && tickets[i][0].equals(now)) {
+                // 티켓 사용하고 이동
+                ticketUsed[i] = true;
+                dfs(tickets[i][1], nodes + " " + tickets[i][1], count + 1, tickets);
+                ticketUsed[i] = false;
+            }
+        }
+    }
+}

--- a/jieun/3월첫째주/pgm_타겟넘버.java
+++ b/jieun/3월첫째주/pgm_타겟넘버.java
@@ -1,0 +1,25 @@
+public class pgm_타겟넘버 {
+    int answer = 0;
+
+    public int solution(int[] numbers, int target) {
+        dfs(numbers, 0, target, 0);
+        return answer;
+    }
+
+    public void dfs(int[] numbers, int depth, int target, int sum) {
+        // numbers : 알고리즘을 실행할 대상 배열
+        // depth : 노드의 깊이
+        // target : 타겟 넘버
+        // sum : 이전 노드 까지의 결과 값
+
+        if (depth == numbers.length) { // 마지막 노드까지 탐색한 경우
+            if (target == sum) answer++;
+        } else {
+            // 해당 노드의 값을 더하고 다음 깊이
+            dfs(numbers, depth + 1, target, sum + numbers[depth]);
+            // 해당 노드의 값을 빼고 다음 깊이
+            dfs(numbers, depth + 1, target, sum - numbers[depth]);
+
+        }
+    }
+}


### PR DESCRIPTION
# 문제

### 타겟 넘버

정수들을 적절히 더하거나 빼서 타겟넘버를 만드는 문제 
첫 노드부터 마지막 노드까지 더하거나 빼면서 탐색해야했기에 깊이우선탐색을 떠올림
마지막 노드까지 탐색했을 때 타겟넘버와 결과값이 같으면 정답 카운트를 증가시킴

### 네트워크

깊이 우선 탐색을 통해 해결할 수  있었음 

1. 방문여부 배열 선언 
2. 방문하지 않은 노드인 경우 dfs 탐색을 시작
3. 탐색 시작한 노드를 방문 처리하고, 그 노드 기준으로 연결되어있고 방문하지 않은 노드가 있는경우 dfs 탐색을 진행
4. 탐색이 끝났으면 answer의 수를 증가시킨다 
5. 2-4번을 반복한다 

### 단어 변환 

1. begin과 1개 차이나는 문자열을 찾으며 dfs로 들어간다 
2. 이때 visit[i]= true → dfs → visited[i]=false 하는 이유는 모든 경우의 수를 탐색하기 위함
3. begin과 target이 같은 경우, cnt를 answer에 대입하고 종료 

### 여행 경로

dfs 이용 
현 위치와 타겟의 출발 지점이 같으면 그 티켓을 사용하고 사용했음을 boolean 배열에 설정 

### 가장 먼 노드 

최단 경로이므로 BFS를 통해 문제해결

1. 주어진 edge는 인접행렬에 저장
2. 거리 배열 선언 
3. 노드 1부터 탐색을 시작함, 거리배열이 0이고 방문가능한 노드일 때 거리를 1 증가
4. dist 배열 중에서 max 값을 구함
5. max 값과 같은 dist 개수를 구하여 출력함