### PR TITLE
3월 둘째주 

### DIFF
--- a/jieun/3월둘째주/boj_11725.java
+++ b/jieun/3월둘째주/boj_11725.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj_11725 {
+    public static void main(String[] args) throws IOException {
+        // 인접 리스트
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int n = Integer.parseInt(br.readLine());
+
+        ArrayList<ArrayList<Integer>> list = new ArrayList<>();
+        for (int i = 0; i <= n; i++) // 0부터 초기화 해야함
+            list.add(new ArrayList<>());
+
+        for (int i = 0; i < n - 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            list.get(x).add(y);
+            list.get(y).add(x);
+
+        }
+
+        boolean[] visit = new boolean[n + 1];
+        int[] result = new int[n + 1];
+
+        Queue<Integer> q = new LinkedList<>();
+        q.add(1);
+        visit[1] = true;
+
+        while (!q.isEmpty()) {
+            int v = q.poll();
+            for (int i = 0; i < list.get(v).size(); i++) {
+                int tmp = list.get(v).get(i);
+                if (!visit[tmp]) {
+                    visit[tmp] = true;
+                    result[tmp] = v;
+                    q.add(tmp);
+                }
+            }
+        }
+
+        for (int i = 2; i <= n; i++) {
+            sb.append(result[i] + "\n");
+        }
+        System.out.println(sb);
+
+        // 인접 행렬
+//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+//        StringBuilder sb = new StringBuilder();
+//        int n = Integer.parseInt(br.readLine());
+//
+//        int[][] arr = new int[n + 1][n + 1];
+//        for (int i = 0; i < n-1; i++) {
+//            StringTokenizer st = new StringTokenizer(br.readLine());
+//            int x = Integer.parseInt(st.nextToken());
+//            int y = Integer.parseInt(st.nextToken());
+//            arr[x][y] = arr[y][x] = 1;
+//        }
+//
+//        boolean[] visit = new boolean[n+1];
+//        int[] result = new int[n+1];
+//
+//        Queue<Integer> q = new LinkedList<>();
+//        q.add(1);
+//        visit[1]=true;
+//
+//        while(!q.isEmpty()){
+//            int tmp = q.poll();
+//            for(int i=1;i<=n;i++){
+//                if((arr[tmp][i]==1||arr[i][tmp]==1) && !visit[i]){
+//                    q.add(i);
+//                    result[i]=tmp;
+//                    visit[i]=true;
+//                }
+//            }
+//        }
+//        for(int i=2;i<=n;i++){
+//            sb.append(result[i]+"\n");
+//        }
+//        System.out.println(sb);
+
+    }
+}

--- a/jieun/3월둘째주/boj_11725.java
+++ b/jieun/3월둘째주/boj_11725.java
@@ -5,83 +5,46 @@ import java.util.*;
 
 public class boj_11725 {
     public static void main(String[] args) throws IOException {
-        // 인접 리스트
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringBuilder sb = new StringBuilder();
+
         int n = Integer.parseInt(br.readLine());
 
-        ArrayList<ArrayList<Integer>> list = new ArrayList<>();
-        for (int i = 0; i <= n; i++) // 0부터 초기화 해야함
-            list.add(new ArrayList<>());
+        ArrayList<ArrayList<Integer>> arr = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            arr.add(new ArrayList<>());
+        }
 
         for (int i = 0; i < n - 1; i++) {
             StringTokenizer st = new StringTokenizer(br.readLine());
-            int x = Integer.parseInt(st.nextToken());
-            int y = Integer.parseInt(st.nextToken());
-
-            list.get(x).add(y);
-            list.get(y).add(x);
-
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            arr.get(a).add(b);
+            arr.get(b).add(a);
         }
 
-        boolean[] visit = new boolean[n + 1];
-        int[] result = new int[n + 1];
-
         Queue<Integer> q = new LinkedList<>();
+        boolean[] visit = new boolean[n + 1];
+        int[] parent = new int[n + 1];
+
         q.add(1);
         visit[1] = true;
 
         while (!q.isEmpty()) {
             int v = q.poll();
-            for (int i = 0; i < list.get(v).size(); i++) {
-                int tmp = list.get(v).get(i);
-                if (!visit[tmp]) {
-                    visit[tmp] = true;
-                    result[tmp] = v;
-                    q.add(tmp);
+            for (int next : arr.get(v)) {
+                if (!visit[next]) {
+                    visit[next] = true;
+                    parent[next] = v;
+                    q.add(next);
                 }
             }
         }
 
         for (int i = 2; i <= n; i++) {
-            sb.append(result[i] + "\n");
+           sb.append(parent[i]+"\n");
         }
         System.out.println(sb);
-
-        // 인접 행렬
-//        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-//        StringBuilder sb = new StringBuilder();
-//        int n = Integer.parseInt(br.readLine());
-//
-//        int[][] arr = new int[n + 1][n + 1];
-//        for (int i = 0; i < n-1; i++) {
-//            StringTokenizer st = new StringTokenizer(br.readLine());
-//            int x = Integer.parseInt(st.nextToken());
-//            int y = Integer.parseInt(st.nextToken());
-//            arr[x][y] = arr[y][x] = 1;
-//        }
-//
-//        boolean[] visit = new boolean[n+1];
-//        int[] result = new int[n+1];
-//
-//        Queue<Integer> q = new LinkedList<>();
-//        q.add(1);
-//        visit[1]=true;
-//
-//        while(!q.isEmpty()){
-//            int tmp = q.poll();
-//            for(int i=1;i<=n;i++){
-//                if((arr[tmp][i]==1||arr[i][tmp]==1) && !visit[i]){
-//                    q.add(i);
-//                    result[i]=tmp;
-//                    visit[i]=true;
-//                }
-//            }
-//        }
-//        for(int i=2;i<=n;i++){
-//            sb.append(result[i]+"\n");
-//        }
-//        System.out.println(sb);
 
     }
 }

--- a/jieun/3월둘째주/boj_1325.java
+++ b/jieun/3월둘째주/boj_1325.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj_1325 {
+    static int max = Integer.MIN_VALUE;
+    static int[] result;
+    static int n, m;
+    static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph.get(a).add(b);
+        }
+
+        result = new int[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            bfs(i);
+        }
+
+        for (int i = 1; i < n + 1; i++) {
+            max = Math.max(result[i], max);
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (max == result[i])
+                sb.append(i + " ");
+        }
+        System.out.println(sb);
+
+    }
+
+    static void bfs(int x) {
+        Queue<Integer> q = new LinkedList<>();
+        boolean[] visit = new boolean[n + 1];
+        q.add(x);
+        visit[x] = true;
+        while (!q.isEmpty()) {
+            int v = q.poll();
+            for (int next : graph.get(v)) {
+                if (!visit[next]) {
+                    visit[next] = true;
+                    q.add(next);
+                    result[next]++;//*
+                }
+            }
+        }
+    }
+
+
+}

--- a/jieun/3월둘째주/boj_16918.java
+++ b/jieun/3월둘째주/boj_16918.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class boj_16918 {
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int r = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        char[][] map = new char[r][c];
+        int[][] bombtime = new int[r][c];
+        for (int i = 0; i < r; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < c; j++) {
+                map[i][j] = s.charAt(j);
+                if (map[i][j] == 'O') {
+                    bombtime[i][j] = 3; // 폭탄 터질 시간 (놓인시간 +3)
+                }
+            }
+        }
+
+        int time = 0;
+        int[] dx = {-1, 1, 0, 0};
+        int[] dy = {0, 0, -1, 1};
+
+        while (time++ < n) {
+            if (time % 2 == 0) {
+                // 비어있는 모든 칸에 폭탄을 설치
+                for (int i = 0; i < r; i++) {
+                    for (int j = 0; j < c; j++) {
+                        if (map[i][j] == '.') {
+                            map[i][j] = 'O';
+                            bombtime[i][j] = time + 3;
+                        }
+                    }
+                }
+            } else{
+                // 시간이 다된 폭탄 터트림
+                for (int i = 0; i < r; i++) {
+                    for (int j = 0; j < c; j++) {
+                        if (bombtime[i][j] == time) {
+                            map[i][j] = '.';
+                            for (int d = 0; d < 4; d++) {
+                                int nx = i + dx[d];
+                                int ny = j + dy[d];
+
+                                if (nx < 0 || ny < 0 || nx >= r || ny >= c) continue;
+
+                                // 이번에 터뜨려야할 폭탄을 연쇄반응으로 미리 터뜨리게 되면
+                                // 미리 터뜨린 폭탄의 주변 폭탄을 연쇄시킬 수 없다. 그래서 bomtime을 확인
+                                if (map[nx][ny] == 'O' && bombtime[nx][ny] != time) {
+                                    map[nx][ny] = '.';
+                                    bombtime[nx][ny] = 0;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+        for (int i = 0; i < r; i++) {
+            System.out.println(map[i]);
+        }
+
+    }
+}

--- a/jieun/3월둘째주/boj_2309.java
+++ b/jieun/3월둘째주/boj_2309.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class boj_2309 {
+    static int sum;
+    static int[] arr;
+    static int i,j;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        arr = new int[9];
+        sum =0;
+        for (int l = 0; l < 9; l++) {
+            arr[l] = Integer.parseInt(br.readLine());
+            sum += arr[l];
+        }
+        Arrays.sort(arr);
+
+        remove();
+
+        for (int k = 0; k < 9; k++) {
+            if (k == i || k == j)
+                continue;
+            System.out.println(arr[k]);
+        }
+
+    }
+
+    static void remove(){
+        for (i = 0; i < 9; i++) {
+            for (j = 0; j < 9; j++) {
+                if (i == j) continue;
+                if (sum - arr[i] - arr[j] == 100)
+                    return;
+            }
+        }
+    }
+
+
+}

--- a/jieun/3월둘째주/boj_2606.java
+++ b/jieun/3월둘째주/boj_2606.java
@@ -22,22 +22,18 @@ public class boj_2606 {
 
         boolean[] visit = new boolean[n + 1];
         visit[1] = true;
+
         Queue<Integer> q = new LinkedList<>();
-        for (int i = 1; i <= n; i++) {
-            if (arr[1][i] == 1 || arr[i][1] == 1) {
-                q.add(i);
-                visit[i] = true;
-            }
-        }
+        q.add(1);
 
         int count = 0;
         while (!q.isEmpty()) {
             int tmp = q.poll();
-            count += 1;
             for (int i = 1; i <= n; i++) {
-                if ((arr[tmp][i] == 1 || arr[i][tmp] == 1) && !visit[i]) {
+                if (arr[tmp][i] == 1 && !visit[i]) {
                     q.add(i);
                     visit[i] = true;
+                    count += 1;
                 }
             }
         }

--- a/jieun/3월둘째주/boj_2606.java
+++ b/jieun/3월둘째주/boj_2606.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_2606 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int t = Integer.parseInt(br.readLine());
+
+        int[][] arr = new int[n + 1][n + 1];
+        for (int i = 0; i < t; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            arr[x][y] = arr[y][x] = 1;
+        }
+
+        boolean[] visit = new boolean[n + 1];
+        visit[1] = true;
+        Queue<Integer> q = new LinkedList<>();
+        for (int i = 1; i <= n; i++) {
+            if (arr[1][i] == 1 || arr[i][1] == 1) {
+                q.add(i);
+                visit[i] = true;
+            }
+        }
+
+        int count = 0;
+        while (!q.isEmpty()) {
+            int tmp = q.poll();
+            count += 1;
+            for (int i = 1; i <= n; i++) {
+                if ((arr[tmp][i] == 1 || arr[i][tmp] == 1) && !visit[i]) {
+                    q.add(i);
+                    visit[i] = true;
+                }
+            }
+        }
+        System.out.println(count);
+    }
+}

--- a/jieun/3월둘째주/boj_2606.java
+++ b/jieun/3월둘째주/boj_2606.java
@@ -10,33 +10,34 @@ public class boj_2606 {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
         int n = Integer.parseInt(br.readLine());
-        int t = Integer.parseInt(br.readLine());
+        int m = Integer.parseInt(br.readLine());
 
         int[][] arr = new int[n + 1][n + 1];
-        for (int i = 0; i < t; i++) {
+        for (int i = 0; i < m; i++) {
             StringTokenizer st = new StringTokenizer(br.readLine());
-            int x = Integer.parseInt(st.nextToken());
-            int y = Integer.parseInt(st.nextToken());
-            arr[x][y] = arr[y][x] = 1;
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            arr[a][b] = arr[b][a] = 1;
         }
 
-        boolean[] visit = new boolean[n + 1];
-        visit[1] = true;
-
         Queue<Integer> q = new LinkedList<>();
+        boolean[] visit = new boolean[n + 1];
+
         q.add(1);
+        visit[1] = true;
 
         int count = 0;
         while (!q.isEmpty()) {
-            int tmp = q.poll();
+            int v = q.poll();
             for (int i = 1; i <= n; i++) {
-                if (arr[tmp][i] == 1 && !visit[i]) {
-                    q.add(i);
+                if (arr[v][i] == 1 && !visit[i]) {
                     visit[i] = true;
-                    count += 1;
+                    q.add(i);
+                    count++;
                 }
             }
         }
         System.out.println(count);
     }
+
 }


### PR DESCRIPTION
# 문제

### 2606번 바이러스

> 실행시간 124ms
 
DFS/BFS 문제 - BFS로 해결

1. 인접행렬과 방문배열을 만든다.
2. 1번부터 시작이므로 visit[1]=true, q.add(1)
3. BFS 탐색을 시작한다. 
    큐에서 값(v)을 하나 뺀다. 
    v와 연결된 점(i)이 있을 때 그리고 그 점을 방문하지 않았을 때 큐에 i를 넣고 방문 처리하고 count를 증가시킨다. 
4. count를 출력한다. 

### 11725번 트리의 부모 찾기

> 실행시간 788ms

DFS/BFS 문제 - BFS로 해결 

1. 인접리스트(arr)를 선언하고 입력값을 넣어준다.
2. 방문 배열(visit)과 부모를 저장할 배열(parent)을 선언한다.
3. 루트 1부터 시작이므로 1을 큐에 넣어주고 방문처리한다.
4. 큐가 비어있지 않을 때,
4-1. 원소(v)를 하나 꺼낸다.
4-2. 그 원소(v)에 해당하는 인접리스트 배열로 for문을 실행한다
4-3. for문을 돌며 다음 원소(next)를 방문하지 않았을 때, 방문처리, 결과 배열에 넣기, 큐에 넣기
5. 2부터 결과를 출력한다.

### 1325 효율적인 해킹

> 실행시간 8492ms

DFS/BFS 문제 - BFS 로 해결

1. 인접리스트를 먼저 초기화하고 입력값을 넣어준다. 
2. 모든 컴퓨터(i)를 BFS(i) 수행한다.
    2-1. i를 큐에 넣고, 방문처리
    2-2. 큐가 비어있지 않을 때 
           큐에서 값(v)을 하나 빼준다.
           그 값(v)에 해당하는 리스트(graph.get(v))로 for문을 실행한다. 
           방문하지 않는 요소(next)라면 방문처리, 큐에 요소 넣기, result[next]++
3. max 값을 찾는다.
4. result 배열에서 max 값과 같은 값이 있다면 그 값에 해당하는 컴퓨터를 출력한다.

### 16918 봄버맨

> 실행시간 304ms

- 짝수 초에 폭탄을 놓고, 홀수초에 폭탄을 터뜨린다.
- 폭탄을 놓을 때 비어있는 칸에 bombtime 이중 배열을 선언해 폭탄 놓인시간 +3 ==폭탄이 터질 time을 저장, 터뜨릴 때 bombtime의 값이 time과 동일한지 확인한 후 터뜨리면 된다

### 2309 일곱 난쟁이

> 실행시간 124ms

1. 입력값을 배열에 저장하며 sum을 구한다.
2. 배열을 정렬한다. 
3. remove함수를 실행
    이중 for문을 이용해서 sum에서 값을 두개 뺀 값이 100인 경우 return해준다. 
4. 반복문을 이용해 배열을 출력하되 뺀 두 값의 인덱스에 해당하는 값은 출력하지 않는다.